### PR TITLE
adjust random initialization in main.c

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -2,7 +2,7 @@
 
 ## Game settings
 
-MAX_SCORE=70           # Maximum score to end the game
+MAX_SCORE=400          # Maximum score to end the game
 MAX_TIME=100            # Maximum time for the game (sec)
 MIN_ENERGY=30           # Minimum energy for a player
 MAX_ENERGY=500          # Maximum energy for a player

--- a/src/main.c
+++ b/src/main.c
@@ -124,13 +124,13 @@ void fork_players(Player *players, int num_players, Team team, char *binary_path
 
         const pid_t pid = fork();
 
-        init_random(getpid());
-
         if (pid == -1) {
             perror("fork");
         }
 
         else if (pid == 0) {
+
+            init_random(getpid());
 
             close(pipefd[0]); // Close read end in child
 


### PR DESCRIPTION
This pull request includes changes to the game configuration settings and the `fork_players` function in the main source file. The most important changes include increasing the maximum score to end the game and moving the initialization of the random number generator in the `fork_players` function.

Changes to game configuration settings:

* [`config.txt`](diffhunk://#diff-a9b5c214b62651a1af8e7f600485ee6b280c815745eabb52c06bbccb2397b5f8L5-R5): Increased the `MAX_SCORE` value from 70 to 400.

Changes to `fork_players` function:

* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L127-R134): Moved the `init_random(getpid())` call to after the fork to ensure it is only called in the child process.