### PR TITLE
Update energy handling to effort; adjust player position calculations

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -69,27 +69,27 @@ int main(int argc, char *argv[]) {
         float total_A = 0.0f, total_B = 0.0f;
 
         for (int i = 0; i < config.NUM_PLAYERS/2; i++) {
-            float energy;
-            ssize_t bytes = read(pipe_fds_team_A[i], &energy, sizeof(float));
+            float effort;
+            ssize_t bytes = read(pipe_fds_team_A[i], &effort, sizeof(float));
 
 
             if (bytes == sizeof(float) || bytes == 0) {
-                printf("Team A - Player %d energy: %.2f\n", i, energy);
-                total_A += energy;
+                printf("Team A - Player %d effort: %.2f\n", i, effort);
+                total_A += effort;
             }
         }
 
         for (int i = 0; i < config.NUM_PLAYERS/2; i++) {
-            float energy;
-            ssize_t bytes = read(pipe_fds_team_B[i], &energy, sizeof(float));
+            float effort;
+            ssize_t bytes = read(pipe_fds_team_B[i], &effort, sizeof(float));
             if (bytes == sizeof(float) || bytes == 0) {
-                printf("Team B - Player %d energy: %.2f\n", i, energy);
-                total_B += energy;
+                printf("Team B - Player %d effort: %.2f\n", i, effort);
+                total_B += effort;
             }
         }
 
         float score = total_A - total_B;
-        printf("\nTotal Energy A: %.2f | Total Energy B: %.2f | Score: %.2f\n\n", total_A, total_B, score);
+        printf("\nTotal Effort A: %.2f | Total Effort B: %.2f | Score: %.2f\n\n", total_A, total_B, score);
 
         if (score >= config.MAX_SCORE) {
             printf("🏆 Team A wins!\n");

--- a/src/player.c
+++ b/src/player.c
@@ -15,15 +15,16 @@ Player *current_player;
 
 void send_energy(int signum) {
     // Decrease energy based on rate_decay * position
-    const int position = current_player->number + 1;
-    current_player->energy -= current_player->rate_decay * position;
+    current_player->energy -= current_player->rate_decay;
     if (current_player->energy < 0.0f) {
         printf("ok\n");
         current_player->energy = 0.0f;
     }
 
-    // Send energy to parent
-    write(write_fd, &current_player->energy, sizeof(float));
+    // Send effort to parent
+
+    float effort = current_player->energy * ((float) current_player->position);
+    write(write_fd, &effort, sizeof(float));
 
     // Schedule next alarm
     alarm(1);

--- a/src/utils/random.c
+++ b/src/utils/random.c
@@ -19,6 +19,6 @@ void generate_random_player(Player *player, Config *configs, Team team, int numb
     player->team = team;
     player->falling_chance = random_float(configs->MIN_FALLING_CHANCE, configs->MAX_FALLING_CHANCE);
     player->number = number;
-    player->position = number;
-    player->new_position = number;
+    player->position = number+1;
+    player->new_position = number+1;
 }

--- a/src/utils/referee_orders.c
+++ b/src/utils/referee_orders.c
@@ -16,7 +16,7 @@ void align(Player* team, int num_players) {
     qsort(team, num_players, sizeof(Player), compare_players);
     
     for (int i = 0; i < num_players; i++) {
-        team[i].new_position = i;
+        team[i].new_position = i+1;
         printf("Player %d: energy = %.2f\n", team[i].number, team[i].energy);
     }
 }


### PR DESCRIPTION
This pull request includes several changes across multiple files to standardize the terminology from "energy" to "effort" and adjust player positions. The most important changes include renaming variables and updating calculations to reflect these terminological changes.

Terminology updates:

* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L72-R92): Changed variable names from `energy` to `effort` and updated related print statements to reflect these changes.
* [`src/player.c`](diffhunk://#diff-be6c10a281956279b3126103cd06a5c1573197dd6bb7b13f8b59409d9903f5aaL18-R27): Updated the `send_energy` function to use `effort` instead of `energy` and adjusted the calculation to include the player's position.

Player position adjustments:

* [`src/utils/random.c`](diffhunk://#diff-55064b7575f8882b8c2b7d7a75038ad264e34a8b53bc084d6561fa29ed0a4b2fL22-R23): Modified the `generate_random_player` function to initialize player positions starting from `number+1` instead of `number`.
* [`src/utils/referee_orders.c`](diffhunk://#diff-59572cd1fecd516a08cd34fd783a7d85b0b46019b0562d4661bcc06d1693f547L19-R19): Updated the `align` function to set `new_position` starting from `i+1` instead of `i`.