### PR TITLE
Fix pipe indexing for player communication; ensure correct player num…

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -36,7 +36,8 @@ Team simulate_round(int pipe_fds_team_A[], int pipe_fds_team_B[], const Config *
     // Process Team A efforts
     for (int i = 0; i < config->NUM_PLAYERS/2; i++) {
         Message message;
-        ssize_t bytes = read(pipe_fds_team_A[i], &message, sizeof(Message));
+        int index_pipe = game->players_teamA[i].number;
+        ssize_t bytes = read(pipe_fds_team_A[index_pipe], &message, sizeof(Message));
 
         if (bytes == sizeof(Message) || bytes == 0) {
             snprintf(temp_buffer, sizeof(temp_buffer),
@@ -59,7 +60,8 @@ Team simulate_round(int pipe_fds_team_A[], int pipe_fds_team_B[], const Config *
     // Process Team B efforts
     for (int i = 0; i < config->NUM_PLAYERS/2; i++) {
         Message message;
-        ssize_t bytes = read(pipe_fds_team_B[i], &message, sizeof(Message));
+        int index_pipe = game->players_teamB[i].number;
+        ssize_t bytes = read(pipe_fds_team_B[index_pipe], &message, sizeof(Message));
 
         if (bytes == sizeof(Message) || bytes == 0) {
             snprintf(temp_buffer, sizeof(temp_buffer),

--- a/src/referee.c
+++ b/src/referee.c
@@ -162,14 +162,14 @@ void fork_players(Player *players, int num_players, Team team,
             exit(EXIT_FAILURE);
         }
 
-        read_fds[i] = energy_pipe_fds[0];
+        read_fds[players[i].number] = energy_pipe_fds[0];
 
         int pos_pipe_fds_temp[2];
         if (pipe(pos_pipe_fds_temp) == -1) {
             perror("pipe");
             exit(EXIT_FAILURE);
         }
-        pos_pipe_fds[i] = pos_pipe_fds_temp[1];  // Parent writes on this end later
+        pos_pipe_fds[players[i].number] = pos_pipe_fds_temp[1];  // Parent writes on this end later
 
         const pid_t pid = fork();
 
@@ -244,7 +244,8 @@ void cleanup_processes(const Player *players_teamA, const Player *players_teamB,
 
 void send_new_positions(Player *players, int num_players, int pos_pipe_fds[]) {
     for (int i = 0; i < num_players; i++) {
-        if (write(pos_pipe_fds[i], &players[i].new_position, sizeof(int)) <=0) {
+        int index_pipe = players[i].number;
+        if (write(pos_pipe_fds[index_pipe], &players[i].new_position, sizeof(int)) <=0) {
             perror("write to pos pipe");
             fflush(stderr);
             usleep(10000);
@@ -257,7 +258,8 @@ void send_new_positions(Player *players, int num_players, int pos_pipe_fds[]) {
 void read_player_energies(Player *players, int num_players, int pos_pipe_fds[]) {
     for (int i = 0; i < num_players; i++) {
         float energy;
-        if (read(pos_pipe_fds[i], &energy, sizeof(float)) <= 0) {
+        int index_pipe = players[i].number;
+        if (read(pos_pipe_fds[index_pipe], &energy, sizeof(float)) <= 0) {
             perror("read from energy pipe");
         }
 

--- a/src/utils/referee_orders.c
+++ b/src/utils/referee_orders.c
@@ -7,8 +7,8 @@
 static int compare_players(const void* a, const void* b) {
     Player* p1 = (Player*)a;
     Player* p2 = (Player*)b;
-    if (p1->attributes.energy > p2->attributes.energy) return 1;
-    if (p1->attributes.energy < p2->attributes.energy) return -1;
+    if (p1->attributes.energy > p2->attributes.energy) return -1;
+    if (p1->attributes.energy < p2->attributes.energy) return 1;
     return 0;
 }
 
@@ -16,19 +16,8 @@ void align(Player* team, int num_players, int *read_fds, int *pos_pipe_fds) {
     // Use qsort to sort team by energy level
     qsort(team, num_players, sizeof(Player), compare_players);
 
-    int temp1[num_players];
-    int temp2[num_players];
-    
     for (int i = 0; i < num_players; i++) {
-        team[i].new_position = i+1;
+        team[i].new_position = num_players - i;
     }
 
-    for (int i = 0; i < num_players; i++) {
-        int index = team[i].position - 1;
-        temp1[index] = read_fds[i];
-        temp2[index] = pos_pipe_fds[i];
-    }
-
-    memcpy(read_fds, temp1, sizeof(int) * num_players);
-    memcpy(pos_pipe_fds, temp2, sizeof(int) * num_players);
 }


### PR DESCRIPTION
This pull request includes several changes to the `src/game.c`, `src/referee.c`, and `src/utils/referee_orders.c` files to improve the handling of player indices and sorting of players by energy levels. The most important changes include modifying how player indices are used in pipe operations and correcting the sorting order of players by energy.

### Improvements to player index handling:

* [`src/game.c`](diffhunk://#diff-94fb337d7329cc8d07d0a1478b275494a6b01dd63e7ed865a80cddd1f5305221L39-R40): Modified the `simulate_round` function to use the player's number as the index for reading from pipes for both Team A and Team B. [[1]](diffhunk://#diff-94fb337d7329cc8d07d0a1478b275494a6b01dd63e7ed865a80cddd1f5305221L39-R40) [[2]](diffhunk://#diff-94fb337d7329cc8d07d0a1478b275494a6b01dd63e7ed865a80cddd1f5305221L62-R64)
* [`src/referee.c`](diffhunk://#diff-cd3f9ead19f2773960e28dd24d8d7252f596f22f0db2e678d5e7bc48930df20aL165-R172): Updated the `fork_players` function to use the player's number for setting up `read_fds` and `pos_pipe_fds`.
* [`src/referee.c`](diffhunk://#diff-cd3f9ead19f2773960e28dd24d8d7252f596f22f0db2e678d5e7bc48930df20aL247-R248): Adjusted the `send_new_positions` and `read_player_energies` functions to use the player's number as the index for writing to and reading from pipes. [[1]](diffhunk://#diff-cd3f9ead19f2773960e28dd24d8d7252f596f22f0db2e678d5e7bc48930df20aL247-R248) [[2]](diffhunk://#diff-cd3f9ead19f2773960e28dd24d8d7252f596f22f0db2e678d5e7bc48930df20aL260-R262)

### Fixes to player sorting:

* [`src/utils/referee_orders.c`](diffhunk://#diff-59572cd1fecd516a08cd34fd783a7d85b0b46019b0562d4661bcc06d1693f547L10-L33): Corrected the `compare_players` function to sort players in descending order of energy. Removed unnecessary temporary arrays and simplified the `align` function to update player positions directly.…ber is used for reading and writing to pipes