### PR TITLE
Enhance CI workflow; add release creation and asset upload steps for …

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+# Add permissions to allow release creation and asset uploads
+permissions:
+  contents: write
+
 env:
   BUILD_TYPE: Release
 
@@ -29,54 +33,67 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: ctest -C ${{ env.BUILD_TYPE }}
 
+      # Only create release on PR merge to master
+      - name: Check if PR merge
+        id: check_pr_merge
+        if: github.event_name == 'push'
+        run: |
+          PR_MERGE=$(git log -1 --pretty=format:%s | grep -c "^Merge pull request")
+          echo "is_pr_merge=$PR_MERGE" >> $GITHUB_OUTPUT
+
       - name: Create Release
         id: create_release
+        if: github.event_name == 'push' && steps.check_pr_merge.outputs.is_pr_merge == '1'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.sha }}
           release_name: Release ${{ github.sha }}
-          body: ${{ github.event.pull_request.body || 'No description provided' }}
+          body: ${{ github.event.head_commit.message }}
           draft: false
           prerelease: false
 
       - name: Upload referee
+        if: github.event_name == 'push' && steps.check_pr_merge.outputs.is_pr_merge == '1'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/build/referee
+          asset_path: ${{ github.workspace }}/bin/referee
           asset_name: referee
           asset_content_type: application/octet-stream
 
       - name: Upload player
+        if: github.event_name == 'push' && steps.check_pr_merge.outputs.is_pr_merge == '1'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/build/player
+          asset_path: ${{ github.workspace }}/bin/player
           asset_name: player
           asset_content_type: application/octet-stream
 
-      - name: Upload rope\_game\_graphics
+      - name: Upload rope_game_graphics
+        if: github.event_name == 'push' && steps.check_pr_merge.outputs.is_pr_merge == '1'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/build/rope_game_graphics
+          asset_path: ${{ github.workspace }}/bin/rope_game_graphics
           asset_name: rope_game_graphics
           asset_content_type: application/octet-stream
 
-      - name: Upload rope\_pulling\_game\_main
+      - name: Upload rope_pulling_game_main
+        if: github.event_name == 'push' && steps.check_pr_merge.outputs.is_pr_merge == '1'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/build/rope_pulling_game_main
+          asset_path: ${{ github.workspace }}/bin/rope_pulling_game_main
           asset_name: rope_pulling_game_main
           asset_content_type: application/octet-stream


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for a CMake project running on a single platform. The changes streamline the workflow by removing comments and adding new steps for creating and uploading release assets.

Streamlining the workflow:

* [`.github/workflows/cmake-single-platform.yml`](diffhunk://#diff-1a15c496bc27579c31f047b79e8aeb193569e1f7441d2bebff42a8d22928c3dbL1-L2): Removed unnecessary comments to clean up the workflow file. [[1]](diffhunk://#diff-1a15c496bc27579c31f047b79e8aeb193569e1f7441d2bebff42a8d22928c3dbL1-L2) [[2]](diffhunk://#diff-1a15c496bc27579c31f047b79e8aeb193569e1f7441d2bebff42a8d22928c3dbL12-L19) [[3]](diffhunk://#diff-1a15c496bc27579c31f047b79e8aeb193569e1f7441d2bebff42a8d22928c3dbL28-R82)

Adding release steps:

* [`.github/workflows/cmake-single-platform.yml`](diffhunk://#diff-1a15c496bc27579c31f047b79e8aeb193569e1f7441d2bebff42a8d22928c3dbL28-R82): Added steps to create a release and upload assets (`referee`, `player`, `rope_game_graphics`, `rope_pulling_game_main`) using `actions/create-release@v1` and `actions/upload-release-asset@v1`.