### PR TITLE
Add team members section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,9 @@ make
 cd bin && ./rope_pulling_game_main
 ```
 
+## Team Members
+
+- [Yazan Abualoun](https://github.com/yazan6546)
+- [Ghazi Al-Hajj Qasem](https://github.com/ghazicc)
+- [Ahmad Qaimari](https://github.com/ahmadqaimari)
+- [Emil Khoury](https://github.com/khouryEmil)


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a new section listing the team members with their GitHub profiles.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126-R131): Added a "Team Members" section with links to the GitHub profiles of Yazan Abualoun, Ghazi Al-Hajj Qasem, Ahmad Qaimari, and Emil Khoury.