### PR TITLE
Update cmake-single-platform.yml

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to specify a more precise build environment.

Workflow configuration update:

* [`.github/workflows/cmake-single-platform.yml`](diffhunk://#diff-1a15c496bc27579c31f047b79e8aeb193569e1f7441d2bebff42a8d22928c3dbL19-R19): Changed the `runs-on` environment from `ubuntu-latest` to `ubuntu-18.04` to ensure consistent builds on a specific version of Ubuntu.